### PR TITLE
フェードの終了フラグを作成

### DIFF
--- a/Scenes/root.unity
+++ b/Scenes/root.unity
@@ -54,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 0
   m_LightmapEditorSettings:
-    serializedVersion: 10
+    serializedVersion: 12
     m_Resolution: 1
     m_BakeResolution: 50
     m_AtlasSize: 1024
@@ -62,6 +62,7 @@ LightmapSettings:
     m_AOMaxDistance: 1
     m_CompAOExponent: 0
     m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
     m_Padding: 2
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
@@ -76,10 +77,16 @@ LightmapSettings:
     m_PVRDirectSampleCount: 32
     m_PVRSampleCount: 500
     m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
     m_PVRFilterTypeDirect: 0
     m_PVRFilterTypeIndirect: 0
     m_PVRFilterTypeAO: 0
-    m_PVRFilteringMode: 1
+    m_PVREnvironmentMIS: 0
     m_PVRCulling: 1
     m_PVRFilteringGaussRadiusDirect: 1
     m_PVRFilteringGaussRadiusIndirect: 5
@@ -88,6 +95,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
     m_ShowResolutionOverlay: 1
+    m_ExportTrainingData: 0
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 0
 --- !u!196 &5
@@ -112,6 +120,75 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &237105797
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1216576064294506164, guid: a40d8f8ea7048774b93ef090ad9be19c,
+        type: 3}
+      propertyPath: m_Name
+      value: AdManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 1216576064294506186, guid: a40d8f8ea7048774b93ef090ad9be19c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 167.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1216576064294506186, guid: a40d8f8ea7048774b93ef090ad9be19c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 354
+      objectReference: {fileID: 0}
+    - target: {fileID: 1216576064294506186, guid: a40d8f8ea7048774b93ef090ad9be19c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1216576064294506186, guid: a40d8f8ea7048774b93ef090ad9be19c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1216576064294506186, guid: a40d8f8ea7048774b93ef090ad9be19c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1216576064294506186, guid: a40d8f8ea7048774b93ef090ad9be19c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1216576064294506186, guid: a40d8f8ea7048774b93ef090ad9be19c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1216576064294506186, guid: a40d8f8ea7048774b93ef090ad9be19c,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1216576064294506186, guid: a40d8f8ea7048774b93ef090ad9be19c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1216576064294506186, guid: a40d8f8ea7048774b93ef090ad9be19c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1216576064294506186, guid: a40d8f8ea7048774b93ef090ad9be19c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a40d8f8ea7048774b93ef090ad9be19c, type: 3}
 --- !u!1001 &647702248
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -215,7 +292,7 @@ GameObject:
   - component: {fileID: 1972613196}
   m_Layer: 5
   m_Name: dummyCamera
-  m_TagString: Untagged
+  m_TagString: MainCamera
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -245,9 +322,10 @@ Camera:
   m_ClearFlags: 2
   m_BackGroundColor: {r: 1, g: 1, b: 1, a: 1}
   m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_GateFitMode: 2
   m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2

--- a/Scripts/Scene/SceneManager.cs
+++ b/Scripts/Scene/SceneManager.cs
@@ -27,8 +27,8 @@ namespace VMUnityLib
 
         Stack<KeyValuePair<string, int>> sceneAnchor = new Stack<KeyValuePair<string, int>>();    // シーンのアンカー.
 
-        bool            isFadeWaiting = false;
-        bool            isFadeEnd  = false;      // フェード終了フラグ
+        bool isFadeWaiting = false;
+        public bool isFadeEnd { get; private set; } = false;      // フェード終了フラグ
         CommonSceneUI   sceneUI = null;
 
         [SceneNameAttribute, SerializeField] string firstSceneName = default;
@@ -353,18 +353,6 @@ namespace VMUnityLib
 
             // フェード終了フラグを立てる
             isFadeEnd = true;
-        }
-
-        /// <summary>
-        /// フェード終了フラグの受け渡し関数
-        /// </summary>
-        /// <returns>フェード終了フラグの値</returns>
-        public bool GetIsFadeEnd()
-        {
-            bool returnflg = isFadeEnd;
-            isFadeEnd = false;
-
-            return returnflg;
         }
 
         /// <summary>

--- a/Scripts/Scene/SceneManager.cs
+++ b/Scripts/Scene/SceneManager.cs
@@ -358,7 +358,7 @@ namespace VMUnityLib
         /// <summary>
         /// フェード終了フラグの受け渡し関数
         /// </summary>
-        /// <returns></returns>
+        /// <returns>フェード終了フラグの値</returns>
         public bool GetIsFadeEnd()
         {
             bool returnflg = isFadeEnd;

--- a/Scripts/Scene/SceneManager.cs
+++ b/Scripts/Scene/SceneManager.cs
@@ -28,6 +28,7 @@ namespace VMUnityLib
         Stack<KeyValuePair<string, int>> sceneAnchor = new Stack<KeyValuePair<string, int>>();    // シーンのアンカー.
 
         bool            isFadeWaiting = false;
+        bool            isFadeEnd  = false;      // フェード終了フラグ
         CommonSceneUI   sceneUI = null;
 
         [SceneNameAttribute, SerializeField] string firstSceneName = default;
@@ -124,6 +125,7 @@ namespace VMUnityLib
         /// <param name="pushAnchor">シーンまでのアンカー.</param>
         public void PushScene(string SceneName, SceneChangeFadeParam fadeParam, AfterSceneControlDelegate afterSceneControlDelegate = null, string pushAnchor = null)
         {
+            isFadeEnd = false;
             isFadeWaiting = true;
             CmnFadeManager.Inst.StartFadeOut(EndFadeOutCallBack, fadeParam.fadeOutTime, fadeParam.fadeType, fadeParam.fadeColor);
             StartCoroutine(PushSceneInternal(SceneName, fadeParam, afterSceneControlDelegate, pushAnchor));
@@ -171,6 +173,7 @@ namespace VMUnityLib
         /// <param name="fadeTime">フェードパラメータ.</param>
         public void ChangeScene(string SceneName, SceneChangeFadeParam fadeParam, AfterSceneControlDelegate afterSceneControlDelegate = null)
         {
+            isFadeEnd = false;
             isFadeWaiting = true;
             CmnFadeManager.Inst.StartFadeOut(EndFadeOutCallBack, fadeParam.fadeOutTime, fadeParam.fadeType, fadeParam.fadeColor);
             StartCoroutine(ChangeSceneInternal(SceneName, fadeParam, afterSceneControlDelegate));
@@ -200,6 +203,7 @@ namespace VMUnityLib
         /// <param name="fadeTime">フェードパラメータ.</param>
         public void PopScene(SceneChangeFadeParam fadeParam, AfterSceneControlDelegate afterSceneControlDelegate = null)
         {
+            isFadeEnd = false;
             isFadeWaiting = true;
             CmnFadeManager.Inst.StartFadeOut(EndFadeOutCallBack, fadeParam.fadeOutTime, fadeParam.fadeType, fadeParam.fadeColor);
             StartCoroutine(PopSceneInternal(fadeParam, afterSceneControlDelegate));
@@ -230,6 +234,7 @@ namespace VMUnityLib
         /// <param name="fadeTime">フェードパラメータ.</param>
         public void PopSceneToAnchor(string anchorName, SceneChangeFadeParam fadeParam, AfterSceneControlDelegate afterSceneControlDelegate = null)
         {
+            isFadeEnd = false;
             isFadeWaiting = true;
 
             // アンカーが無ければ警告出して無視
@@ -345,6 +350,21 @@ namespace VMUnityLib
             {
                 currentSceneRoot.BroadcastMessage(CmnMonoBehaviour.FADE_END_NAME, SendMessageOptions.DontRequireReceiver);
             }
+
+            // フェード終了フラグを立てる
+            isFadeEnd = true;
+        }
+
+        /// <summary>
+        /// フェード終了フラグの受け渡し関数
+        /// </summary>
+        /// <returns></returns>
+        public bool GetIsFadeEnd()
+        {
+            bool returnflg = isFadeEnd;
+            isFadeEnd = false;
+
+            return returnflg;
         }
 
         /// <summary>


### PR DESCRIPTION
タイマーの開始時間がOnEnableだとタイミングがまちまちになってしまうので、フェードイン終了時のコールバックにフェード終了フラグを追加して処理のタイミングを合わせました。

・SceneManager.cs
　シーンのプッシュ、チェンジ、ポップのそれぞれの最初でフェード終了フラグをリセットし、
　コールバック時にフラグを立てるようにしました。