### PR TITLE
ロードUIがフェードアウトしたらオブジェクトをオフにする

### DIFF
--- a/Scripts/Loading/LoadingUIManager.cs
+++ b/Scripts/Loading/LoadingUIManager.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using UnityEngine.Events;
 
 namespace VMUnityLib
 {
@@ -57,7 +58,15 @@ namespace VMUnityLib
         public void HideLoadingUI(LibBridgeInfo.LoadingType type)
         {
 #if USE_TWEEN
+            // フェードアウト
             loadingUiDict[type].tweenAlpha.Play(PlayDirection.Reverse);
+            // フェードアウトが終わったら、オブジェクトをオフにする
+            UnityAction onEndFadeout = null;
+            loadingUiDict[type].tweenAlpha.onFinished.AddListener(onEndFadeout = () =>
+            {
+                loadingUiDict[type].tweenAlpha.gameObject.SetActive(false);
+                loadingUiDict[type].tweenAlpha.onFinished.RemoveListener(onEndFadeout);
+            });
 #endif
         }
     }


### PR DESCRIPTION
ロードUIがフェードアウトしたときに、UIのオブジェクトがオンになったままなせいで、次にロードUIを表示したときに、LoadingUIBaseを継承したロードUIクラスでStart関数が呼ばれていなかった。
なので、ロードが終了してUIがフェードアウトしたらオブジェクトをオフにするようにした。