### PR TITLE
Unity6000.3.1f1 でSwitch2をビルドするための修正

### DIFF
--- a/Scripts/Shader/Editor/ShaerVariantSwitcher.cs
+++ b/Scripts/Shader/Editor/ShaerVariantSwitcher.cs
@@ -22,6 +22,11 @@ public class ShaderVariantSwitcher : IPreprocessBuildWithReport
         {
             variantCollection = AssetDatabase.LoadAssetAtPath<ShaderVariantCollection>("Assets/MyGameAssets/LibBridge/AutoShaderVariantsSwitch.shadervariants");
         }
+        else if(target == BuildTarget.Switch2)
+        {
+            // FIXME: y.saitu Switch2用のShaderVariantCollectionを追加する(ビルド優先のため暫定対応)
+            variantCollection = AssetDatabase.LoadAssetAtPath<ShaderVariantCollection>("Assets/MyGameAssets/LibBridge/AutoShaderVariantsSwitch.shadervariants");
+        }
 
         if (variantCollection == null)
         {

--- a/Scripts/Shader/Editor/ShaerVariantSwitcher.cs
+++ b/Scripts/Shader/Editor/ShaerVariantSwitcher.cs
@@ -24,8 +24,8 @@ public class ShaderVariantSwitcher : IPreprocessBuildWithReport
         }
         else if(target == BuildTarget.Switch2)
         {
-            // FIXME: y.saitu Switch2用のShaderVariantCollectionを追加する(ビルド優先のため暫定対応)
-            variantCollection = AssetDatabase.LoadAssetAtPath<ShaderVariantCollection>("Assets/MyGameAssets/LibBridge/AutoShaderVariantsSwitch.shadervariants");
+            // FIXME: y.saitu Switch1のファイルをコピーして使用(ビルド優先のため暫定対応)
+            variantCollection = AssetDatabase.LoadAssetAtPath<ShaderVariantCollection>("Assets/MyGameAssets/LibBridge/AutoShaderVariantsSwitch2.shadervariants");
         }
 
         if (variantCollection == null)

--- a/Scripts/Utility/GraphicSettingsApplyer.cs
+++ b/Scripts/Utility/GraphicSettingsApplyer.cs
@@ -97,7 +97,7 @@ public class GraphicSettingsApplyer
         ApplyFrameRate(0);
 #endif
         // ロード高速化のためにCPUブースト戻す
-#if !UNITY_EDITOR && !UNITY_SWITCH && !UNITY_STANDALONE_WIN
+#if !UNITY_EDITOR && !UNITY_SWITCH && !UNITY_STANDALONE_WIN && !UNITY_SWITCH2
         UnityEngine.Switch.Performance.SetCpuBoostMode(UnityEngine.Switch.Performance.CpuBoostMode.Normal);
 #endif
         Application.backgroundLoadingPriority = ThreadPriority.Low;
@@ -216,7 +216,7 @@ public class GraphicSettingsApplyer
         ApplyFrameRate(0, LoadBoostingFrameRate);
 
         // ロード高速化のためにCPUブースト
-#if !UNITY_EDITOR && !UNITY_SWITCH && !UNITY_STANDALONE_WIN
+#if !UNITY_EDITOR && !UNITY_SWITCH && !UNITY_STANDALONE_WIN && !UNITY_SWITCH2
         UnityEngine.Switch.Performance.SetCpuBoostMode(UnityEngine.Switch.Performance.CpuBoostMode.FastLoad);
 #endif
         Application.backgroundLoadingPriority = ThreadPriority.High;


### PR DESCRIPTION
■修正内容
- Switch2用のAutoShaderVariantsSwitch2をSwitch1のものをコピーして作成